### PR TITLE
Add standalone kind signature after GHC 9.2

### DIFF
--- a/src/Type/Errors.hs
+++ b/src/Type/Errors.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 ------------------------------------------------------------------------------
 -- | This module provides useful tools for writing better type-errors. For
 -- a quickstart guide to the underlying 'GHC.TypeLits.TypeError' machinery,
@@ -101,6 +103,9 @@ type family PrettyPrintList (vs :: [k]) :: ErrorMessage where
 -- ...
 --
 -- @since 0.1.0.0
+#if __GLASGOW_HASKELL__ >= 902
+type ShowTypeQuoted :: k -> ErrorMessage
+#endif
 type family ShowTypeQuoted (t :: k) :: ErrorMessage where
   ShowTypeQuoted (t :: Symbol) = 'ShowType t
   ShowTypeQuoted t             = 'Text "'" ':<>: 'ShowType t ':<>: 'Text "'"

--- a/type-errors.cabal
+++ b/type-errors.cabal
@@ -56,6 +56,9 @@ library
   if impl(ghc < 8.6)
     default-extensions:
         TypeInType
+  if impl(ghc >= 9.2)
+    default-extensions:
+        StandaloneKindSignatures
   default-language: Haskell2010
 
 test-suite test
@@ -89,4 +92,7 @@ test-suite test
   if impl(ghc < 8.6)
     default-extensions:
         TypeInType
+  if impl(ghc >= 9.2)
+    default-extensions:
+        StandaloneKindSignatures
   default-language: Haskell2010


### PR DESCRIPTION
Currently running doctest against GHC 9.2 would fail with:
```
src/Type/Errors.hs:106:19: error:
    • Expected kind ‘k’, but ‘t :: Symbol’ has kind ‘Symbol’
    • In the first argument of ‘ShowTypeQuoted’, namely ‘(t :: Symbol)’
      In the type family declaration for ‘ShowTypeQuoted’
```
IIUC, the reason is that [CUSKs](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/poly_kinds.html#extension-CUSKs) is no longer enabled by default in `GHC2021`. The library builds fine because its default language is `Haskell2010`, while the doctest inherits the default ghci environment (which is `GHC2021` in this case) to load code of the library. According to the [migration guide](https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.2#polymorphic-recursion-for-datatype-declarations), we can add a standalone kind signature for `ShowTypeQuoted` to make the library compile even without CUSKs, so that the doctest could run normally.  An alternative fix is to simply enable CUSKs in the doctest environment, no need to modify the library.